### PR TITLE
Add crawl requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,6 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
-# Overwrite or add rules to create your own house style
-#
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false

--- a/app/models/crawl_request.rb
+++ b/app/models/crawl_request.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CrawlRequest < ApplicationRecord
+  enum :crawl_type, { single_page: 0, entire_site: 1 }
+  enum :status, { pending: 0, in_progress: 1, completed: 2, failed: 3 }
+
+  validates :url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: "must be a valid URL" }
+  validates :crawl_type, presence: true
+  validates :status, presence: true
+end

--- a/db/migrate/20240618111930_create_crawl_requests.rb
+++ b/db/migrate/20240618111930_create_crawl_requests.rb
@@ -1,0 +1,10 @@
+class CreateCrawlRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :crawl_requests do |t|
+      t.string :url, null: false
+      t.integer :crawl_type, null: false
+      t.integer :status, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 0) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_18_111930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "crawl_requests", force: :cascade do |t|
+    t.string "url", null: false
+    t.integer "crawl_type", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/spec/factories/crawl_requests.rb
+++ b/spec/factories/crawl_requests.rb
@@ -1,0 +1,32 @@
+
+FactoryBot.define do
+  factory :crawl_request do
+    url { "http://example.com" }
+    crawl_type { :single_page }
+    status { :pending }
+
+    trait :single_page do
+      crawl_type { :single_page }
+    end
+
+    trait :entire_site do
+      crawl_type { :entire_site }
+    end
+
+    trait :pending do
+      status { :pending }
+    end
+
+    trait :in_progress do
+      status { :in_progress }
+    end
+
+    trait :completed do
+      status { :completed }
+    end
+
+    trait :failed do
+      status { :failed }
+    end
+  end
+end

--- a/spec/models/crawl_request_spec.rb
+++ b/spec/models/crawl_request_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe CrawlRequest, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:url) }
+    it { should validate_presence_of(:crawl_type) }
+    it { should validate_presence_of(:status) }
+
+    it { should define_enum_for(:crawl_type).with_values([:single_page, :entire_site]) }
+    it { should define_enum_for(:status).with_values([:pending, :in_progress, :completed, :failed]) }
+
+    it do
+      should allow_values("http://example.com", "https://example.com").for(:url)
+      should_not allow_values("example", "htp://example", "ftp://example.com").for(:url)
+    end
+  end
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,4 @@
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
### Changes
Adds a model for crawl requests, which will be used to queue up URLs to
be crawled.

### Why?

As of now, I'm thinking the user will eventually be able to submit a
URL to be crawled, and the system will queue up the URL to be crawled
by the crawler. The crawler will then fetch the page, parse it, and
store the response in S3. The metadata about the crawl response will be
stored in the database. But all this is still TBD.