### PR TITLE
Set up initial crawl behavior

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem "administrate"
+gem "httparty"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -62,4 +62,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,9 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     csv (3.3.0)
     date (3.3.4)
@@ -121,6 +124,7 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.1.0)
     httparty (0.22.0)
       csv
       mini_mime (>= 1.0.0)
@@ -345,6 +349,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
@@ -385,6 +393,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webmock
 
 BUNDLED WITH
    2.5.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -120,6 +121,10 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -164,6 +169,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.23.1)
     msgpack (1.7.2)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     net-imap (0.4.12)
       date
       net-protocol
@@ -362,6 +369,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  httparty
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/controllers/admin/crawl_jobs_controller.rb
+++ b/app/controllers/admin/crawl_jobs_controller.rb
@@ -1,0 +1,10 @@
+module Admin
+  class CrawlJobsController < Admin::ApplicationController
+    def create
+      crawl_request = CrawlRequest.find(params[:crawl_request_id])
+      CrawlWebPageJob.perform_later(crawl_request.id)
+      crawl_request.update(status: "in_progress")
+      redirect_to admin_crawl_request_path(crawl_request), notice: "Crawl job has been triggered."
+    end
+  end
+end

--- a/app/dashboards/crawl_request_dashboard.rb
+++ b/app/dashboards/crawl_request_dashboard.rb
@@ -11,6 +11,7 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
     id: Field::Number,
     crawl_type: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    failure_message: Field::String,
     url: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
@@ -25,6 +26,7 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
     id
     crawl_type
     status
+    failure_message
     url
   ].freeze
 
@@ -34,6 +36,7 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
     id
     crawl_type
     status
+    failure_message
     url
     created_at
     updated_at
@@ -45,6 +48,7 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     crawl_type
     status
+    failure_message
     url
   ].freeze
 

--- a/app/jobs/crawl_web_page_job.rb
+++ b/app/jobs/crawl_web_page_job.rb
@@ -1,0 +1,15 @@
+class CrawlWebPageJob < ApplicationJob
+  queue_as :default
+
+  def perform(crawl_request_id, crawler = Crawlers::SimpleCrawler.new)
+    crawl_request = CrawlRequest.find(crawl_request_id)
+    result = crawler.fetch(crawl_request.url)
+
+    if result[:success]
+      # TODO: Save the response and details
+      crawl_request.update(status: "completed", failure_message: nil)
+    else
+      crawl_request.update(status: "failed", failure_message: result[:error])
+    end
+  end
+end

--- a/app/models/crawl_request.rb
+++ b/app/models/crawl_request.rb
@@ -2,7 +2,7 @@
 
 class CrawlRequest < ApplicationRecord
   enum :crawl_type, { single_page: 0, entire_site: 1 }
-  enum :status, { pending: 0, in_progress: 1, completed: 2, failed: 3 }
+  enum :status, { pending: 0, in_progress: 10, completed: 20, failed: 30 }
 
   validates :url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: "must be a valid URL" }
   validates :crawl_type, presence: true

--- a/app/services/crawlers/base_crawler.rb
+++ b/app/services/crawlers/base_crawler.rb
@@ -1,0 +1,5 @@
+class Crawlers::BaseCrawler
+  def fetch(url)
+    raise NotImplementedError, "Subclasses must implement the fetch method"
+  end
+end

--- a/app/services/crawlers/base_crawler.rb
+++ b/app/services/crawlers/base_crawler.rb
@@ -1,5 +1,7 @@
-class Crawlers::BaseCrawler
-  def fetch(url)
-    raise NotImplementedError, "Subclasses must implement the fetch method"
+module Crawlers
+  class BaseCrawler
+    def fetch(url)
+      raise NotImplementedError, "Subclasses must implement the fetch method"
+    end
   end
 end

--- a/app/services/crawlers/crawlers.rb
+++ b/app/services/crawlers/crawlers.rb
@@ -1,0 +1,2 @@
+module Crawlers
+end

--- a/app/services/crawlers/crawlers.rb
+++ b/app/services/crawlers/crawlers.rb
@@ -1,2 +1,0 @@
-module Crawlers
-end

--- a/app/services/crawlers/simple_crawler.rb
+++ b/app/services/crawlers/simple_crawler.rb
@@ -1,0 +1,13 @@
+class Crawlers::SimpleCrawler < Crawlers::BaseCrawler
+  def fetch(url)
+    response = HTTParty.get(url)
+
+    if response.success?
+      { success: true, body: response.body }
+    else
+      { success: false, error: response.code }
+    end
+  rescue StandardError => e
+    { success: false, error: e.message }
+  end
+end

--- a/app/services/crawlers/simple_crawler.rb
+++ b/app/services/crawlers/simple_crawler.rb
@@ -1,13 +1,15 @@
-class Crawlers::SimpleCrawler < Crawlers::BaseCrawler
-  def fetch(url)
-    response = HTTParty.get(url)
+module Crawlers
+  class SimpleCrawler < BaseCrawler
+    def fetch(url)
+      response = HTTParty.get(url)
 
-    if response.success?
-      { success: true, body: response.body }
-    else
-      { success: false, error: response.code }
+      if response.success?
+        { success: true, body: response.body }
+      else
+        { success: false, error: response.code }
+      end
+    rescue StandardError => e
+      { success: false, error: e.message }
     end
-  rescue StandardError => e
-    { success: false, error: e.message }
   end
 end

--- a/app/views/admin/crawl_requests/show.html.erb
+++ b/app/views/admin/crawl_requests/show.html.erb
@@ -1,0 +1,74 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if accessible_action?(page.resource, :edit) %>
+
+    <%= link_to(
+      t("administrate.actions.destroy"),
+      [namespace, page.resource],
+      class: "button button--danger",
+      method: :delete,
+      data: { confirm: t("administrate.actions.confirm") }
+    ) if accessible_action?(page.resource, :destroy) %>
+
+    <!- Begin template customization >
+    <%= link_to(
+      "Trigger Crawl",
+      admin_crawl_request_crawl_jobs_path(page.resource),
+      method: :post,
+      class: "button"
+    ) %>
+    <!- End template customization >
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |title, attributes| %>
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend><%= t "helpers.label.#{page.resource_name}.#{title}", default: title %></legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label" id="<%= attribute.name %>">
+          <%= t(
+            "helpers.label.#{resource_name}.#{attribute.name}",
+            default: page.resource.class.human_attribute_name(attribute.name),
+          ) %>
+          </dt>
+
+          <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+              ><%= render_field attribute, page: page %></dd>
+        <% end %>
+      </fieldset>
+    <% end %>
+  </dl>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   namespace :admin do
-      resources :crawl_requests
+      resources :crawl_requests do
+        resources :crawl_jobs, only: [:create]
+      end
 
       root to: "crawl_requests#index"
     end

--- a/db/migrate/20240619103621_add_failure_message_to_crawl_requests.rb
+++ b/db/migrate/20240619103621_add_failure_message_to_crawl_requests.rb
@@ -1,0 +1,5 @@
+class AddFailureMessageToCrawlRequests < ActiveRecord::Migration[7.2]
+  def change
+    add_column :crawl_requests, :failure_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_06_18_111930) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_19_103621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,5 +20,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_18_111930) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "failure_message"
   end
 end

--- a/spec/jobs/crawl_web_page_job_spec.rb
+++ b/spec/jobs/crawl_web_page_job_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe CrawlWebPageJob, type: :job do
+  it "updates the status to completed when the crawl is successful" do
+    crawl_request = create(:crawl_request)
+    crawler = mock_crawler_with(success: true, body: "<html></html>")
+
+    described_class.perform_now(crawl_request.id, crawler)
+
+    crawl_request.reload
+    expect(crawl_request.status).to eq("completed")
+    expect(crawl_request.failure_message).to be_nil
+  end
+
+  it "updates the status to failed with the failure message when the crawl fails" do
+    crawl_request = create(:crawl_request)
+    crawler = mock_crawler_with(success: false, error: "500")
+
+    described_class.perform_now(crawl_request.id, crawler)
+
+    crawl_request.reload
+    expect(crawl_request.status).to eq("failed")
+    expect(crawl_request.failure_message).to eq("500")
+  end
+
+  def mock_crawler_with(result)
+    crawler = instance_double("Crawlers::SimpleCrawler")
+    allow(crawler).to receive(:fetch).and_return(result)
+    crawler
+  end
+end

--- a/spec/models/crawl_request_spec.rb
+++ b/spec/models/crawl_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CrawlRequest, type: :model do
     it { should validate_presence_of(:status) }
 
     it { should define_enum_for(:crawl_type).with_values([:single_page, :entire_site]) }
-    it { should define_enum_for(:status).with_values([:pending, :in_progress, :completed, :failed]) }
+    it { should define_enum_for(:status).with_values(pending: 0, in_progress: 10, completed: 20, failed: 30) }
 
     it do
       should allow_values("http://example.com", "https://example.com").for(:url)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require_relative '../config/environment'
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require "webmock/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/services/crawlers/base_crawler_spec.rb
+++ b/spec/services/crawlers/base_crawler_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Crawlers::BaseCrawler, type: :model do
+  it "raises NotImplementedError when fetch is called" do
+    crawler = Crawlers::BaseCrawler.new
+
+    expect { crawler.fetch("http://example.com") }.to raise_error(
+      NotImplementedError, "Subclasses must implement the fetch method"
+    )
+  end
+end

--- a/spec/services/crawlers/simple_crawler_spec.rb
+++ b/spec/services/crawlers/simple_crawler_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Crawlers::SimpleCrawler, type: :model do
+  it "returns success with body and status when the response is successful" do
+    stub_request(:get, "http://example.com").to_return(status: 200, body: "<html></html>")
+
+    crawler = Crawlers::SimpleCrawler.new
+    result = crawler.fetch("http://example.com")
+
+    expect(result).to eq({ success: true, body: "<html></html>" })
+  end
+
+  it "returns failure with status when the response is unsuccessful" do
+    stub_request(:get, "http://example.com").to_return(status: 500)
+
+    crawler = Crawlers::SimpleCrawler.new
+    result = crawler.fetch("http://example.com")
+
+    expect(result).to eq({ success: false, error: 500 })
+  end
+
+  it "returns failure with error message when a StandardError is raised" do
+    allow(HTTParty).to receive(:get).and_raise(StandardError.new("Something went wrong"))
+
+    crawler = Crawlers::SimpleCrawler.new
+    result = crawler.fetch("http://example.com")
+
+    expect(result).to eq({ success: false, error: "Something went wrong" })
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,7 +76,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
### Changes

Adds initial crawl behavior and allows an admin to trigger it via a new button.

### Why?

This PR just adds preliminary setup. We'll eventually need something more advanced that can handle, e.g.

* Redirects and redirect chains
* Retry logic and throttling
* Storing request metadata, such as status codes, number of attempts
* Storing the body of a successful response in an external bucket

But for now these new additions allow us to focus on the happy path and map out that behavior. We can address everything else as the need arises.

### Screenshots


![Screenshot 2024-06-19 at 7 26 31 AM](https://github.com/seanmack/copydog-ai/assets/5815877/e7d8de94-d489-40ec-b820-fe760863ce9a)
![Screenshot 2024-06-19 at 7 26 53 AM](https://github.com/seanmack/copydog-ai/assets/5815877/266baa6f-1f44-43d8-a8b4-56a6e9b91e13)
![Screenshot 2024-06-19 at 7 27 36 AM](https://github.com/seanmack/copydog-ai/assets/5815877/b3e4fe30-3d1a-4d42-9794-2c6570ff01b9)

