### PR TITLE
Crawls save HTML response

### DIFF
--- a/app/jobs/crawl_web_page_job.rb
+++ b/app/jobs/crawl_web_page_job.rb
@@ -6,10 +6,27 @@ class CrawlWebPageJob < ApplicationJob
     result = crawler.fetch(crawl_request.url)
 
     if result[:success]
-      # TODO: Save the response and details
-      crawl_request.update(status: "completed", failure_message: nil)
+      handle_success(crawl_request, result)
     else
-      crawl_request.update(status: "failed", failure_message: result[:error])
+      handle_failure(crawl_request, result)
     end
+  end
+
+  private
+
+  def handle_success(crawl_request, result)
+    crawl_request.html_response.purge if crawl_request.html_response.attached?
+
+    crawl_request.html_response.attach(
+      io: StringIO.new(result[:body]),
+      filename: "crawl_response_#{crawl_request.id}.html",
+      content_type: "text/html"
+    )
+
+    crawl_request.update(status: "completed", failure_message: nil)
+  end
+
+  def handle_failure(crawl_request, result)
+    crawl_request.update(status: "failed", failure_message: result[:error])
   end
 end

--- a/app/models/crawl_request.rb
+++ b/app/models/crawl_request.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CrawlRequest < ApplicationRecord
+  has_one_attached :html_response
+
   enum :crawl_type, { single_page: 0, entire_site: 1 }
   enum :status, { pending: 0, in_progress: 10, completed: 20, failed: 30 }
 

--- a/app/views/admin/crawl_requests/show.html.erb
+++ b/app/views/admin/crawl_requests/show.html.erb
@@ -38,14 +38,12 @@ as well as a link to its edit page.
       data: { confirm: t("administrate.actions.confirm") }
     ) if accessible_action?(page.resource, :destroy) %>
 
-    <!- Begin template customization >
     <%= link_to(
       "Trigger Crawl",
       admin_crawl_request_crawl_jobs_path(page.resource),
       method: :post,
       class: "button"
     ) %>
-    <!- End template customization >
   </div>
 </header>
 
@@ -67,6 +65,12 @@ as well as a link to its edit page.
 
           <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
               ><%= render_field attribute, page: page %></dd>
+        <% end %>
+
+        <% if page.resource.html_response.attached? %>
+          <dt class="attribute-label">HTML Response</dt>
+          <dd class="attribute-data"
+              ><%= link_to "Download", rails_blob_path(page.resource.html_response, disposition: "attachment"), target: "_blank" %></dd>
         <% end %>
       </fieldset>
     <% end %>

--- a/db/migrate/20240620022035_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20240620022035_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_06_19_103621) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_20_022035) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "crawl_requests", force: :cascade do |t|
     t.string "url", null: false
@@ -22,4 +50,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_19_103621) do
     t.datetime "updated_at", null: false
     t.string "failure_message"
   end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/spec/jobs/crawl_web_page_job_spec.rb
+++ b/spec/jobs/crawl_web_page_job_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CrawlWebPageJob, type: :job do
-  it "updates the status to completed when the crawl is successful" do
+  it "updates the status to completed when the crawl is successful and attaches the HTML response" do
     crawl_request = create(:crawl_request)
     crawler = mock_crawler_with(success: true, body: "<html></html>")
 
@@ -10,6 +10,10 @@ RSpec.describe CrawlWebPageJob, type: :job do
     crawl_request.reload
     expect(crawl_request.status).to eq("completed")
     expect(crawl_request.failure_message).to be_nil
+    expect(crawl_request.html_response.attached?).to be true
+
+    html_response = crawl_request.html_response.download
+    expect(html_response).to eq("<html></html>")
   end
 
   it "updates the status to failed with the failure message when the crawl fails" do
@@ -21,6 +25,25 @@ RSpec.describe CrawlWebPageJob, type: :job do
     crawl_request.reload
     expect(crawl_request.status).to eq("failed")
     expect(crawl_request.failure_message).to eq("500")
+    expect(crawl_request.html_response.attached?).to be false
+  end
+
+  it "purges the existing attachment before attaching a new one" do
+    crawl_request = create(:crawl_request)
+    first_crawler = mock_crawler_with(success: true, body: "<html>First</html>")
+    second_crawler = mock_crawler_with(success: true, body: "<html>Second</html>")
+
+    # First time
+    described_class.perform_now(crawl_request.id, first_crawler)
+    crawl_request.reload
+    first_attachment = crawl_request.html_response.download
+    expect(first_attachment).to eq("<html>First</html>")
+
+    # Second time
+    described_class.perform_now(crawl_request.id, second_crawler)
+    crawl_request.reload
+    second_attachment = crawl_request.html_response.download
+    expect(second_attachment).to eq("<html>Second</html>")
   end
 
   def mock_crawler_with(result)

--- a/spec/models/crawl_request_spec.rb
+++ b/spec/models/crawl_request_spec.rb
@@ -14,4 +14,15 @@ RSpec.describe CrawlRequest, type: :model do
       should_not allow_values("example", "htp://example", "ftp://example.com").for(:url)
     end
   end
+
+  describe "attachments" do
+    it "can attach an HTML response" do
+      crawl_request = create(:crawl_request)
+      file = StringIO.new("<html></html>")
+      crawl_request.html_response.attach(io: file, filename: "test.html", content_type: "text/html")
+
+      expect(crawl_request.html_response).to be_attached
+      expect(crawl_request.html_response.blob.filename).to eq("test.html")
+    end
+  end
 end


### PR DESCRIPTION
### Changes

The HTML response retrieved during a crawl is now saved as an attachment. 

### Why?

We want to persist the HTML response so we can analyze and modify it. We'll eventually store these attachments on S3 or similar, but for now storing them locally works well.

### Screenshots

![Screenshot 2024-06-20 at 5 31 51 AM](https://github.com/seanmack/copydog-ai/assets/5815877/18d2f8b1-98a0-497e-a7f3-37f3e5cd8502)
![Screenshot 2024-06-20 at 5 32 18 AM](https://github.com/seanmack/copydog-ai/assets/5815877/8b9d4089-eaff-4ecb-ae85-2578d41af738)

