### PR TITLE
Remove unnecessary crawl_type column from crawl requests

### DIFF
--- a/app/dashboards/crawl_request_dashboard.rb
+++ b/app/dashboards/crawl_request_dashboard.rb
@@ -9,7 +9,6 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    crawl_type: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     failure_message: Field::String,
     url: Field::String,
@@ -24,7 +23,6 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
-    crawl_type
     status
     failure_message
     url
@@ -34,7 +32,6 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
-    crawl_type
     status
     failure_message
     url
@@ -46,7 +43,6 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    crawl_type
     status
     failure_message
     url

--- a/app/models/crawl_request.rb
+++ b/app/models/crawl_request.rb
@@ -3,10 +3,8 @@
 class CrawlRequest < ApplicationRecord
   has_one_attached :html_response
 
-  enum :crawl_type, { single_page: 0, entire_site: 1 }
   enum :status, { pending: 0, in_progress: 10, completed: 20, failed: 30 }
 
   validates :url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: "must be a valid URL" }
-  validates :crawl_type, presence: true
   validates :status, presence: true
 end

--- a/db/migrate/20240620104918_remove_crawl_type_from_crawl_requests.rb
+++ b/db/migrate/20240620104918_remove_crawl_type_from_crawl_requests.rb
@@ -1,0 +1,5 @@
+class RemoveCrawlTypeFromCrawlRequests < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :crawl_requests, :crawl_type, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_06_20_022035) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_20_104918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,7 +44,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_20_022035) do
 
   create_table "crawl_requests", force: :cascade do |t|
     t.string "url", null: false
-    t.integer "crawl_type", null: false
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/crawl_requests.rb
+++ b/spec/factories/crawl_requests.rb
@@ -2,31 +2,6 @@
 FactoryBot.define do
   factory :crawl_request do
     url { "http://example.com" }
-    crawl_type { :single_page }
     status { :pending }
-
-    trait :single_page do
-      crawl_type { :single_page }
-    end
-
-    trait :entire_site do
-      crawl_type { :entire_site }
-    end
-
-    trait :pending do
-      status { :pending }
-    end
-
-    trait :in_progress do
-      status { :in_progress }
-    end
-
-    trait :completed do
-      status { :completed }
-    end
-
-    trait :failed do
-      status { :failed }
-    end
   end
 end

--- a/spec/models/crawl_request_spec.rb
+++ b/spec/models/crawl_request_spec.rb
@@ -3,10 +3,7 @@ require "rails_helper"
 RSpec.describe CrawlRequest, type: :model do
   describe "validations" do
     it { should validate_presence_of(:url) }
-    it { should validate_presence_of(:crawl_type) }
     it { should validate_presence_of(:status) }
-
-    it { should define_enum_for(:crawl_type).with_values([:single_page, :entire_site]) }
     it { should define_enum_for(:status).with_values(pending: 0, in_progress: 10, completed: 20, failed: 30) }
 
     it do


### PR DESCRIPTION
### Changes

Removes `crawl_type` column from crawl requests.

### Why?

It seems like `crawl_type` won't be necessary, at least on the crawl request model. We likely will have some abstraction that handles batch crawls, but all that is still up in the air. Since this column is not helping us now and might never, it's best to remove it.