### PR TITLE
Crawl job persists title tag

### DIFF
--- a/app/dashboards/crawl_request_dashboard.rb
+++ b/app/dashboards/crawl_request_dashboard.rb
@@ -12,6 +12,7 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     failure_message: Field::String,
     url: Field::String,
+    title: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -35,6 +36,7 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
     status
     failure_message
     url
+    title
     created_at
     updated_at
   ].freeze

--- a/app/jobs/crawl_web_page_job.rb
+++ b/app/jobs/crawl_web_page_job.rb
@@ -14,6 +14,8 @@ class CrawlWebPageJob < ApplicationJob
 
   private
 
+  # TODO: This method is long and could use a refactor. But while we're still
+  # developing the feature, it's easiest to see everything in one place.
   def handle_success(crawl_request, result)
     crawl_request.html_response.purge if crawl_request.html_response.attached?
 
@@ -23,7 +25,13 @@ class CrawlWebPageJob < ApplicationJob
       content_type: "text/html"
     )
 
-    crawl_request.update(status: "completed", failure_message: nil)
+    page_analysis = PageAnalysis.new(content: result[:body])
+
+    crawl_request.update(
+      status: "completed",
+      failure_message: nil,
+      title: page_analysis.title,
+    )
   end
 
   def handle_failure(crawl_request, result)

--- a/app/models/crawl_request.rb
+++ b/app/models/crawl_request.rb
@@ -7,4 +7,6 @@ class CrawlRequest < ApplicationRecord
 
   validates :url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: "must be a valid URL" }
   validates :status, presence: true
+
+  store_accessor :analysis, :title
 end

--- a/app/services/page_analysis.rb
+++ b/app/services/page_analysis.rb
@@ -1,0 +1,19 @@
+class PageAnalysis
+  attr_reader :content, :title
+
+  def initialize(content:)
+    @content = content
+    analyze
+  end
+
+  private
+
+  def analyze
+    doc = Nokogiri::HTML(content)
+    @title = extract_title(doc)
+  end
+
+  def extract_title(doc)
+    doc.at_css("title")&.text.presence
+  end
+end

--- a/db/migrate/20240620115005_add_analysis_to_crawl_requests.rb
+++ b/db/migrate/20240620115005_add_analysis_to_crawl_requests.rb
@@ -1,0 +1,5 @@
+class AddAnalysisToCrawlRequests < ActiveRecord::Migration[7.2]
+  def change
+    add_column :crawl_requests, :analysis, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_06_20_104918) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_20_115005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_20_104918) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "failure_message"
+    t.jsonb "analysis", default: {}
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/jobs/crawl_web_page_job_spec.rb
+++ b/spec/jobs/crawl_web_page_job_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe CrawlWebPageJob, type: :job do
     expect(second_attachment).to eq("<html>Second</html>")
   end
 
+  it "extracts and saves the title from the HTML response" do
+    crawl_request = create(:crawl_request)
+    crawler = mock_crawler_with(success: true, body: "<html><head><title>Test Title</title></head><body></body></html>")
+
+    described_class.perform_now(crawl_request.id, crawler)
+
+    crawl_request.reload
+    expect(crawl_request.title).to eq("Test Title")
+  end
+
   def mock_crawler_with(result)
     crawler = instance_double("Crawlers::SimpleCrawler")
     allow(crawler).to receive(:fetch).and_return(result)

--- a/spec/models/crawl_request_spec.rb
+++ b/spec/models/crawl_request_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe CrawlRequest, type: :model do
+  describe "columns" do
+    it { should have_db_column(:analysis).of_type(:jsonb).with_options(default: {}) }
+  end
+
   describe "validations" do
     it { should validate_presence_of(:url) }
     it { should validate_presence_of(:status) }
@@ -20,6 +24,14 @@ RSpec.describe CrawlRequest, type: :model do
 
       expect(crawl_request.html_response).to be_attached
       expect(crawl_request.html_response.blob.filename).to eq("test.html")
+    end
+  end
+
+  describe "store_accessor for analysis" do
+    it "allows setting and getting the title" do
+      crawl_request = create(:crawl_request)
+      crawl_request.title = "Test Title"
+      expect(crawl_request.title).to eq("Test Title")
     end
   end
 end

--- a/spec/services/page_analysis_spec.rb
+++ b/spec/services/page_analysis_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe PageAnalysis do
+  describe "#initialize" do
+    it "extracts the title from the HTML content" do
+      content = "<html><head><title>Test Page</title></head><body></body></html>"
+      analysis = PageAnalysis.new(content: content)
+      expect(analysis.title).to eq("Test Page")
+    end
+
+    it "returns nil if the title tag is not present" do
+      content = "<html><head></head><body></body></html>"
+      analysis = PageAnalysis.new(content: content)
+      expect(analysis.title).to be_nil
+    end
+
+    it "returns nil if the title tag is empty" do
+      content = "<html><head><title></title></head><body></body></html>"
+      analysis = PageAnalysis.new(content: content)
+      expect(analysis.title).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### Changes

When a crawl job is successful, the title tag is persisted. 


### Why?

We want to analyze and preserve key characteristics of the retrieved HTML so we can use it later. For example, if users want to create a new page that is similar to a crawled page, an analysis of the page will help craft an apt prompt.

Upcoming changes will include other key attributes, such as headings, content length, meta tags, etc. 

Note: I considered performing this analysis on the fly so that we didn't need to store these details in the database, but I think the overhead of having to repeatedly analyze the HTML is worth avoiding. But if we change our mind, the PageAnalysis class is flexible enough to be used dynamically, so there's little risk here.