### PR TITLE
Display sanitized html response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem "administrate"
+gem "htmlbeautifier"
 gem "httparty"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.0)
+    htmlbeautifier (1.4.3)
     httparty (0.22.0)
       csv
       mini_mime (>= 1.0.0)
@@ -377,6 +378,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  htmlbeautifier
   httparty
   importmap-rails
   jbuilder

--- a/app/services/sanitizers/base_sanitizer.rb
+++ b/app/services/sanitizers/base_sanitizer.rb
@@ -1,0 +1,23 @@
+module Sanitizers
+  class BaseSanitizer
+    DEFAULT_ELEMENTS_TO_REMOVE = %w[head script style]
+
+    def sanitize
+      raise NotImplementedError, "Subclasses must implement the sanitize method"
+    end
+
+    private
+
+    def extract_inner_html(html_content:, element: "body")
+      Sanitizers::Utilities::InnerHtmlExtractor.new(html_content:, element:).extract_inner_html
+    end
+
+    def remove_elements(html_content:, elements: DEFAULT_ELEMENTS_TO_REMOVE)
+      Sanitizers::Utilities::ElementRemover.new(html_content:, elements:).remove_elements
+    end
+
+    def beautify(html_content:)
+      Sanitizers::Utilities::Beautifier.new(html_content:).beautify
+    end
+  end
+end

--- a/app/services/sanitizers/simple_sanitizer.rb
+++ b/app/services/sanitizers/simple_sanitizer.rb
@@ -1,0 +1,16 @@
+module Sanitizers
+  class SimpleSanitizer < BaseSanitizer
+    attr_reader :html_content
+
+    def initialize(html_content:)
+      @html_content = html_content
+    end
+
+    def sanitize
+      result = extract_inner_html(html_content:)
+      result = remove_elements(html_content: result)
+      result = beautify(html_content: result)
+      result
+    end
+  end
+end

--- a/app/services/sanitizers/utilities/base_utility.rb
+++ b/app/services/sanitizers/utilities/base_utility.rb
@@ -1,0 +1,11 @@
+module Sanitizers
+  module Utilities
+    class BaseUtility
+      attr_reader :html_content
+
+      def initialize(html_content:)
+        @html_content = html_content
+      end
+    end
+  end
+end

--- a/app/services/sanitizers/utilities/beautifier.rb
+++ b/app/services/sanitizers/utilities/beautifier.rb
@@ -1,0 +1,9 @@
+module Sanitizers
+  module Utilities
+    class Beautifier < BaseUtility
+      def beautify
+        HtmlBeautifier.beautify(html_content)
+      end
+    end
+  end
+end

--- a/app/services/sanitizers/utilities/element_remover.rb
+++ b/app/services/sanitizers/utilities/element_remover.rb
@@ -9,7 +9,7 @@ module Sanitizers
       end
 
       def remove_elements
-        doc = Nokogiri::HTML(html_content)
+        doc = Nokogiri::HTML.fragment(html_content)
 
         elements.each do |element|
           doc.css(element).remove

--- a/app/services/sanitizers/utilities/element_remover.rb
+++ b/app/services/sanitizers/utilities/element_remover.rb
@@ -1,0 +1,22 @@
+module Sanitizers
+  module Utilities
+    class ElementRemover < BaseUtility
+      attr_reader :elements
+
+      def initialize(html_content:, elements:)
+        super(html_content:)
+        @elements = elements
+      end
+
+      def remove_elements
+        doc = Nokogiri::HTML(html_content)
+
+        elements.each do |element|
+          doc.css(element).remove
+        end
+
+        doc.to_html
+      end
+    end
+  end
+end

--- a/app/services/sanitizers/utilities/inner_html_extractor.rb
+++ b/app/services/sanitizers/utilities/inner_html_extractor.rb
@@ -1,0 +1,18 @@
+module Sanitizers
+  module Utilities
+    class InnerHtmlExtractor < BaseUtility
+      attr_reader :element
+
+      def initialize(html_content:, element:)
+        super(html_content:)
+        @element = element
+      end
+
+      def extract_inner_html
+        doc = Nokogiri::HTML(html_content)
+        node = doc.at_css(element)
+        node ? node.inner_html : nil
+      end
+    end
+  end
+end

--- a/app/views/admin/crawl_requests/show.html.erb
+++ b/app/views/admin/crawl_requests/show.html.erb
@@ -69,4 +69,14 @@ as well as a link to its edit page.
       </fieldset>
     <% end %>
   </dl>
+
+  <%# TODO: this is just a quick way of displaying the results for now %>
+  <% if page.resource.html_response.attached? %>
+    <h2>Sanitized Content</h2>
+    <div style="overflow-x: auto;">
+      <% html_content = page.resource.html_response.download %>
+      <% sanitized_content = Sanitizers::SimpleSanitizer.new(html_content: html_content).sanitize %>
+      <pre><code><%= sanitized_content %></code></pre>
+    </div>
+  <% end %>
 </section>

--- a/spec/services/sanitizers/base_sanitizer_spec.rb
+++ b/spec/services/sanitizers/base_sanitizer_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Sanitizers::BaseSanitizer do
+  describe "#sanitize" do
+    it "raises a NotImplementedError" do
+      sanitizer = described_class.new
+      expect { sanitizer.sanitize }.to raise_error(NotImplementedError, "Subclasses must implement the sanitize method")
+    end
+  end
+
+  describe "#extract_inner_html" do
+    it "calls InnerHtmlExtractor with the correct arguments and returns the result" do
+      html_content = "<html><head></head><body></body></html>"
+      sanitizer = described_class.new
+      extractor_double = instance_double(Sanitizers::Utilities::InnerHtmlExtractor)
+
+      allow(Sanitizers::Utilities::InnerHtmlExtractor).to receive(:new).with(html_content: html_content, element: "body").and_return(extractor_double)
+      allow(extractor_double).to receive(:extract_inner_html).and_return("<body></body>")
+
+      result = sanitizer.send(:extract_inner_html, html_content: html_content, element: "body")
+
+      expect(result).to eq("<body></body>")
+      expect(Sanitizers::Utilities::InnerHtmlExtractor).to have_received(:new).with(html_content: html_content, element: "body")
+      expect(extractor_double).to have_received(:extract_inner_html)
+    end
+  end
+
+  describe "#remove_elements" do
+    it "calls ElementRemover with the correct arguments and returns the result" do
+      html_content = "<html><head></head><body></body></html>"
+      sanitizer = described_class.new
+      remover_double = instance_double(Sanitizers::Utilities::ElementRemover)
+
+      allow(Sanitizers::Utilities::ElementRemover).to receive(:new).with(html_content: html_content, elements: %w[head script style]).and_return(remover_double)
+      allow(remover_double).to receive(:remove_elements).and_return("<html><body></body></html>")
+
+      result = sanitizer.send(:remove_elements, html_content: html_content)
+
+      expect(result).to eq("<html><body></body></html>")
+      expect(Sanitizers::Utilities::ElementRemover).to have_received(:new).with(html_content: html_content, elements: %w[head script style])
+      expect(remover_double).to have_received(:remove_elements)
+    end
+  end
+
+  describe "#beautify" do
+    it "calls Beautifier with the correct arguments and returns the result" do
+      html_content = "<html><head></head><body></body></html>"
+      sanitizer = described_class.new
+      beautifier_double = instance_double(Sanitizers::Utilities::Beautifier)
+
+      allow(Sanitizers::Utilities::Beautifier).to receive(:new).with(html_content: html_content).and_return(beautifier_double)
+      allow(beautifier_double).to receive(:beautify).and_return("<html>\n  <head>\n  </head>\n  <body>\n  </body>\n</html>")
+
+      result = sanitizer.send(:beautify, html_content: html_content)
+
+      expect(result).to eq("<html>\n  <head>\n  </head>\n  <body>\n  </body>\n</html>")
+      expect(Sanitizers::Utilities::Beautifier).to have_received(:new).with(html_content: html_content)
+      expect(beautifier_double).to have_received(:beautify)
+    end
+  end
+end

--- a/spec/services/sanitizers/simple_sanitizer_spec.rb
+++ b/spec/services/sanitizers/simple_sanitizer_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Sanitizers::SimpleSanitizer do
+  describe "#sanitize" do
+    it "calls extract_inner_html, remove_elements, and beautify in sequence and returns the final result" do
+      html_content = "initial content"
+      sanitizer = described_class.new(html_content:)
+
+      # Stub the inherited methods
+      allow(sanitizer).to receive(:extract_inner_html).with(html_content:).and_return("step 1")
+      allow(sanitizer).to receive(:remove_elements).with(html_content: "step 1").and_return("step 2")
+      allow(sanitizer).to receive(:beautify).with(html_content: "step 2").and_return("step 3")
+
+      result = sanitizer.sanitize
+
+      expect(sanitizer).to have_received(:extract_inner_html).with(html_content:)
+      expect(sanitizer).to have_received(:remove_elements).with(html_content: "step 1")
+      expect(sanitizer).to have_received(:beautify).with(html_content: "step 2")
+      expect(result).to eq("step 3")
+    end
+  end
+end

--- a/spec/services/sanitizers/utilities/beautifier_spec.rb
+++ b/spec/services/sanitizers/utilities/beautifier_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Sanitizers::Utilities::Beautifier do
+  describe "#sanitize" do
+    it "beautifies the HTML content" do
+      html_content = "<html><head><title>Test Title</title>   </head><body><h1>Main Title</h1><p>Some content here.</p></body></html>"
+      beautified_content = HtmlBeautifier.beautify(html_content)
+
+      beautifier = described_class.new(html_content:)
+      result = beautifier.beautify
+
+      expect(result).to eq(beautified_content)
+    end
+  end
+end

--- a/spec/services/sanitizers/utilities/element_remover_spec.rb
+++ b/spec/services/sanitizers/utilities/element_remover_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Sanitizers::Utilities::ElementRemover do
+  describe "#remove_elements" do
+    it "removes elements from the HTML" do
+      elements = %w[head script style]
+
+      html_content = <<-HTML
+        <html>
+          <head>
+            <title>Test Title</title>
+            <style>body { font-family: Arial; }</style>
+            <script>alert('Hello, World!');</script>
+          </head>
+          <body>
+            <h1>Main Title</h1>
+            <p>Some content here.</p>
+          </body>
+        </html>
+      HTML
+
+      result = described_class.new(html_content:, elements:).remove_elements
+
+      elements.each do |element|
+        expect(Nokogiri::HTML(result).at(element)).to be_nil
+      end
+
+      expect(result.strip).to include("<html>")
+      expect(result.strip).to include("<body>")
+      expect(result.strip).to include("<h1>Main Title</h1>")
+      expect(result.strip).to include("<p>Some content here.</p>")
+    end
+  end
+end

--- a/spec/services/sanitizers/utilities/element_remover_spec.rb
+++ b/spec/services/sanitizers/utilities/element_remover_spec.rb
@@ -6,17 +6,15 @@ RSpec.describe Sanitizers::Utilities::ElementRemover do
       elements = %w[head script style]
 
       html_content = <<-HTML
-        <html>
-          <head>
-            <title>Test Title</title>
-            <style>body { font-family: Arial; }</style>
-            <script>alert('Hello, World!');</script>
-          </head>
-          <body>
-            <h1>Main Title</h1>
-            <p>Some content here.</p>
-          </body>
-        </html>
+        <head>
+          <title>Test Title</title>
+          <style>body { font-family: Arial; }</style>
+          <script>alert('Hello, World!');</script>
+        </head>
+        <body>
+          <h1>Main Title</h1>
+          <p>Some content here.</p>
+        </body>
       HTML
 
       result = described_class.new(html_content:, elements:).remove_elements
@@ -25,7 +23,7 @@ RSpec.describe Sanitizers::Utilities::ElementRemover do
         expect(Nokogiri::HTML(result).at(element)).to be_nil
       end
 
-      expect(result.strip).to include("<html>")
+      expect(result.strip).not_to include("<html>")
       expect(result.strip).to include("<body>")
       expect(result.strip).to include("<h1>Main Title</h1>")
       expect(result.strip).to include("<p>Some content here.</p>")

--- a/spec/services/sanitizers/utilities/inner_html_extractor_spec.rb
+++ b/spec/services/sanitizers/utilities/inner_html_extractor_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Sanitizers::Utilities::InnerHtmlExtractor do
+  describe "#extract_inner_html" do
+    it "returns the inner HTML of the body element" do
+      html_content = <<-HTML
+        <html>
+          <head>
+            <title>Test Title</title>
+            <style>body { font-family: Arial; }</style>
+            <script>alert('Hello, World!');</script>
+          </head>
+          <body>
+            <h1>Main Title</h1>
+            <p>Some content here.</p>
+          </body>
+        </html>
+      HTML
+
+      expected_inner_html = <<-HTML
+        <h1>Main Title</h1>
+        <p>Some content here.</p>
+      HTML
+
+      extractor = described_class.new(html_content: html_content, element: "body")
+      result = extractor.extract_inner_html
+
+      expect(result.squish).to eq(expected_inner_html.squish)
+    end
+
+    it "returns nil if the specified element is not found" do
+      html_content = "<html><body><h1>Main Title</h1></body></html>"
+
+      extractor = described_class.new(html_content: html_content, element: "head")
+      result = extractor.extract_inner_html
+
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### Changes

User sees a sanitized version of the retrieved HTML for a given crawl request.

### Why?

While we might want to extract details from the whole HTML response, such as meta tags, we primarily want to work with the main content of the page. The changes here add some preliminary sanitization processes that allow us to dynamically extract only the content we care about. We'll build on these processes soon to further distill the content.

### Notes

I used the `services/` directory for most of the new code. I'm not sure that will make sense long term for all these classes, but while I'm still shaping things, it works well enough. 

### Screenshots

![Screenshot 2024-06-22 at 10 31 31 AM](https://github.com/seanmack/copydog-ai/assets/5815877/21d2ceda-14cb-4c6b-a320-536d40a451b0)


