### PR TITLE
Persist api response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,56 @@
 # What is CopydogAI?
 
 CopydogAI is a brand new project. It will allow a user to pull in an
-existing website's content and structure. The user can then "clean up" the
+existing web page's content. The user can then "clean up" the
 content and make it available via an API for other applications to use.
 
-CopydogAI will also allow a user to generate new content based on
-the existing content and structure. This will allow the user to create a new
-website that is similar to the existing website, but with different content,
-while maintaining other aspects of the existing website, such as the general
-page structure and SEO characteristics.
+## How?
+
+CopydogAI scrapes the content from a web page, sanitizes it by removing
+unwanted elements, then sends it to OpenAI's API for further processing.
+
+The result is a clean, well-formatted version of the original content that
+can be used in a variety of ways.
 
 ## Why?
 
-Migrating a website from one platform to another is a pain. Often, a website
-will have a lot of content this is no longer relevant, such as framework-specific
-markup. Most users don't have the time or resources to manually clean up the
-content, so they end up leaving it as is, which can hurt their SEO. Or they
-end up paying a lot of money to have someone else do it for them.
+I've worked with a number of different CMSs and I've found that
+importing content from one system to another can be a real pain:
+* Sometimes you don't want to import everything, just the primary content.
+* Sometimes you want to fix the content before importing it, e.g. to remove
+  broken links or to reformat the text.
+* Sometimes you want to clone some external site's content and use it as a
+  starting point for building a new original page
 
-CopydogAI aims to make this process easier and more affordable.
+CopydogAI will make it easy to do all of these things.
 
 ## Project Status
 
 CopydogAI is currently in the initial stages of development. I'm working on
 building out the core functionality and getting the basic API up and running.
 
+The best way to follow along with the project is to check out the pull requests,
+which will show you the latest changes and updates.
 
-# Setup
+* **Phase #1 (current)**: Build out the basic features using an MVP approach
+
+* **Phase #2**: Build out the API and add additional features
+
+* **Phase #3**: Add a front-end interface for users to interact with the system
+
+
+## Setup
+
+The system requirements are still being determined. For now, you'll need:
+* Postgres running on your local machine
+* Ruby 3.2.1
+
+### Getting Started
 
 1. Clone this repository
-2. `bin/setup`
-3. `cp example.env .env`
-4. Add your API keys to the `.env` file
+1. `bin/setup`
+1. Run the specs: `rspec`
+1. `cp example.env .env`
+1. Add your OpenAI API key to the `.env` file
+1. Run the server: `rails s`
+1. Visit `http://localhost:3000` in your browser

--- a/app/controllers/admin/web_page_drafts_controller.rb
+++ b/app/controllers/admin/web_page_drafts_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class WebPageDraftsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/crawl_request_dashboard.rb
+++ b/app/dashboards/crawl_request_dashboard.rb
@@ -15,6 +15,7 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
     title: Field::String,
     meta_description: Field::String,
     html_response: AttachmentField,
+    web_page_draft: Field::HasOne,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -41,6 +42,7 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
     title
     meta_description
     html_response
+    web_page_draft
     created_at
     updated_at
   ].freeze

--- a/app/dashboards/web_page_draft_dashboard.rb
+++ b/app/dashboards/web_page_draft_dashboard.rb
@@ -31,10 +31,10 @@ class WebPageDraftDashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-    id
-    body
     crawl_request
     title
+    body
+    id
     created_at
     updated_at
   ].freeze

--- a/app/dashboards/web_page_draft_dashboard.rb
+++ b/app/dashboards/web_page_draft_dashboard.rb
@@ -1,0 +1,69 @@
+require "administrate/base_dashboard"
+
+class WebPageDraftDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    body: Field::Text.with_options(searchable: false),
+    crawl_request: Field::BelongsTo,
+    title: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    body
+    crawl_request
+    title
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    body
+    crawl_request
+    title
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    crawl_request
+    title
+    body
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how web page drafts are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(web_page_draft)
+  #   "WebPageDraft ##{web_page_draft.id}"
+  # end
+end

--- a/app/jobs/crawl_web_page_job.rb
+++ b/app/jobs/crawl_web_page_job.rb
@@ -14,24 +14,39 @@ class CrawlWebPageJob < ApplicationJob
 
   private
 
-  # TODO: This method is long and could use a refactor. But while we're still
+  # TODO: This needs a refactor. But while we're still
   # developing the feature, it's easiest to see everything in one place.
   def handle_success(crawl_request, result)
+    # Purge the existing attachment if it exists
     crawl_request.html_response.purge if crawl_request.html_response.attached?
 
+    # Attach the new HTML response
     crawl_request.html_response.attach(
       io: StringIO.new(result[:body]),
       filename: "crawl_response_#{crawl_request.id}.html",
       content_type: "text/html"
     )
 
+    # Parse the page and send the HTML for analysis (this will need error handling)
     page_analysis = PageAnalysis::Parser.new(content: result[:body])
 
-    crawl_request.update(
+    # Update the crawl request with the analysis results
+    crawl_request.update!(
       status: "completed",
       failure_message: nil,
       title: page_analysis.title,
       meta_description: page_analysis.meta_description
+    )
+
+    # Ask OpenAI to analyze the content of the page
+    body = SendContentForAnalysis.new(html: result[:body]).call
+
+    # Create a web page draft with the analysis results
+    web_page_draft = WebPageDraft.find_or_initialize_by(crawl_request:)
+
+    web_page_draft.update!(
+      title: page_analysis.title || "Web Page Title",
+      body:
     )
   end
 

--- a/app/models/crawl_request.rb
+++ b/app/models/crawl_request.rb
@@ -2,6 +2,7 @@
 
 class CrawlRequest < ApplicationRecord
   has_one_attached :html_response
+  has_one :web_page_draft
 
   enum :status, { pending: 0, in_progress: 10, completed: 20, failed: 30 }
 

--- a/app/models/web_page_draft.rb
+++ b/app/models/web_page_draft.rb
@@ -3,4 +3,13 @@ class WebPageDraft < ApplicationRecord
 
   validates :title, presence: true
   validates :body, presence: true
+  validate :body_must_be_valid_json
+
+  private
+
+  def body_must_be_valid_json
+    JSON.parse(body) if body.present?
+  rescue JSON::ParserError
+    errors.add(:body, "must be valid JSON")
+  end
 end

--- a/app/models/web_page_draft.rb
+++ b/app/models/web_page_draft.rb
@@ -1,0 +1,6 @@
+class WebPageDraft < ApplicationRecord
+  belongs_to :crawl_request, optional: true
+
+  validates :title, presence: true
+  validates :body, presence: true
+end

--- a/app/models/web_page_draft.rb
+++ b/app/models/web_page_draft.rb
@@ -2,14 +2,4 @@ class WebPageDraft < ApplicationRecord
   belongs_to :crawl_request, optional: true
 
   validates :title, presence: true
-  validates :body, presence: true
-  validate :body_must_be_valid_json
-
-  private
-
-  def body_must_be_valid_json
-    JSON.parse(body) if body.present?
-  rescue JSON::ParserError
-    errors.add(:body, "must be valid JSON")
-  end
 end

--- a/app/views/admin/crawl_requests/show.html.erb
+++ b/app/views/admin/crawl_requests/show.html.erb
@@ -72,11 +72,10 @@ as well as a link to its edit page.
 
   <%# TODO: this is just a quick way of displaying the results for now %>
   <% if page.resource.html_response.attached? %>
-    <h2>Primary Content Extracted by OpenAI</h2>
+    <h2>Original HTML response</h2>
     <div style="overflow-x: auto;">
       <% html = page.resource.html_response.download %>
-      <% response = SendContentForAnalysis.new(html:).call %>
-      <pre><code><%= response %></code></pre>
+      <pre><code><%= html %></code></pre>
     </div>
   <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
         resources :crawl_jobs, only: [:create]
       end
 
+      resources :web_page_drafts
+
       root to: "crawl_requests#index"
     end
 

--- a/db/migrate/20240625105849_create_web_page_drafts.rb
+++ b/db/migrate/20240625105849_create_web_page_drafts.rb
@@ -2,9 +2,8 @@ class CreateWebPageDrafts < ActiveRecord::Migration[7.2]
   def change
     create_table :web_page_drafts do |t|
       t.string :title, null: false
-      t.jsonb :body, default: {}, null: false
       t.references :crawl_request, null: true, foreign_key: true
-
+      t.text :body
       t.timestamps
     end
   end

--- a/db/migrate/20240625105849_create_web_page_drafts.rb
+++ b/db/migrate/20240625105849_create_web_page_drafts.rb
@@ -1,0 +1,11 @@
+class CreateWebPageDrafts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :web_page_drafts do |t|
+      t.string :title, null: false
+      t.jsonb :body, default: {}, null: false
+      t.references :crawl_request, null: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,8 +53,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_25_105849) do
 
   create_table "web_page_drafts", force: :cascade do |t|
     t.string "title", null: false
-    t.jsonb "body", default: {}, null: false
     t.bigint "crawl_request_id"
+    t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["crawl_request_id"], name: "index_web_page_drafts_on_crawl_request_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_06_20_115005) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_25_105849) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_20_115005) do
     t.jsonb "analysis", default: {}
   end
 
+  create_table "web_page_drafts", force: :cascade do |t|
+    t.string "title", null: false
+    t.jsonb "body", default: {}, null: false
+    t.bigint "crawl_request_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["crawl_request_id"], name: "index_web_page_drafts_on_crawl_request_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "web_page_drafts", "crawl_requests"
 end

--- a/lib/open_ai_service/client.rb
+++ b/lib/open_ai_service/client.rb
@@ -15,7 +15,6 @@ module OpenAiService
     def build_parameters(prompt:, content:)
       {
         model: "gpt-3.5-turbo",
-        response_format: { type: "json_object" },
         messages: [
           { role: "system", content: prompt },
           { role: "user", content: content }

--- a/lib/open_ai_service/client.rb
+++ b/lib/open_ai_service/client.rb
@@ -5,16 +5,22 @@ module OpenAiService
     end
 
     def send_request(prompt:, content:)
-      response = @client.chat(
-        parameters: {
-          model: "gpt-3.5-turbo",
-          messages: [
-            { role: "system", content: prompt },
-            { role: "user", content: content }
-          ]
-        }
-      )
+      parameters = build_parameters(prompt:, content:)
+      response = @client.chat(parameters:)
       response.dig("choices", 0, "message", "content")
+    end
+
+    private
+
+    def build_parameters(prompt:, content:)
+      {
+        model: "gpt-3.5-turbo",
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: prompt },
+          { role: "user", content: content }
+        ]
+      }
     end
   end
 end

--- a/lib/open_ai_service/strategies/extract_main_content_strategy.rb
+++ b/lib/open_ai_service/strategies/extract_main_content_strategy.rb
@@ -5,11 +5,10 @@ module OpenAiService
         <<~PROMPT.strip
           You are an assistant that processes HTML documents and extracts the main content. \
           Remove all non-essential elements such as navigation, advertisements, and footers. \
-          Format the main content into sections with titles and paragraphs. The title should be \
+          Format the main content into sections with titles and paragraphs. Each title should be \
           put in an H2 tag, and the paragraphs should be put in P tags. HTML tags within the \
-          body content should be preserved. Return the result as a JSON array of objects. Each \
-          object should have a title attribute pointing to a string that represents the title of \
-          the section, and a content attribute pointing to an HTML string containing p tags.
+          body content should be preserved. Return the H2 tags and P tags only. Do not wrap the \
+          content in any additional tags. Do not include backticks or code blocks.
         PROMPT
       end
 

--- a/lib/open_ai_service/strategies/extract_main_content_strategy.rb
+++ b/lib/open_ai_service/strategies/extract_main_content_strategy.rb
@@ -7,7 +7,9 @@ module OpenAiService
           Remove all non-essential elements such as navigation, advertisements, and footers. \
           Format the main content into sections with titles and paragraphs. The title should be \
           put in an H2 tag, and the paragraphs should be put in P tags. HTML tags within the \
-          body content should be preserved.
+          body content should be preserved. Return the result as a JSON array of objects. Each \
+          object should have a title attribute pointing to a string that represents the title of \
+          the section, and a content attribute pointing to an HTML string containing p tags.
         PROMPT
       end
 

--- a/spec/factories/web_page_drafts.rb
+++ b/spec/factories/web_page_drafts.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :web_page_draft do
     title { "MyString" }
-    body { "" }
+    body { '{"content": [{"title": "Section 1", "html": "<p>Content</p>"}]}' }
     crawl_request { nil }
   end
 end

--- a/spec/factories/web_page_drafts.rb
+++ b/spec/factories/web_page_drafts.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :web_page_draft do
     title { "MyString" }
-    body { '{"content": [{"title": "Section 1", "html": "<p>Content</p>"}]}' }
+    body { "MyText" }
     crawl_request { nil }
   end
 end

--- a/spec/factories/web_page_drafts.rb
+++ b/spec/factories/web_page_drafts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :web_page_draft do
+    title { "MyString" }
+    body { "" }
+    crawl_request { nil }
+  end
+end

--- a/spec/lib/open_ai_service/client_spec.rb
+++ b/spec/lib/open_ai_service/client_spec.rb
@@ -25,4 +25,25 @@ RSpec.describe OpenAiService::Client do
       expect(result).to eq("Test response")
     end
   end
+
+  describe "#build_parameters" do
+    it "builds the correct parameters for the OpenAI API request" do
+      prompt = "Test prompt"
+      content = "Test content"
+
+      client = OpenAiService::Client.new
+      parameters = client.send(:build_parameters, prompt:, content:)
+
+      expected_parameters = {
+        model: "gpt-3.5-turbo",
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: prompt },
+          { role: "user", content: content }
+        ]
+      }
+
+      expect(parameters).to eq(expected_parameters)
+    end
+  end
 end

--- a/spec/lib/open_ai_service/client_spec.rb
+++ b/spec/lib/open_ai_service/client_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe OpenAiService::Client do
 
       expected_parameters = {
         model: "gpt-3.5-turbo",
-        response_format: { type: "json_object" },
         messages: [
           { role: "system", content: prompt },
           { role: "user", content: content }

--- a/spec/lib/open_ai_service/strategies/extract_main_content_strategy_spec.rb
+++ b/spec/lib/open_ai_service/strategies/extract_main_content_strategy_spec.rb
@@ -1,20 +1,6 @@
 require "rails_helper"
 
 RSpec.describe OpenAiService::Strategies::ExtractMainContentStrategy do
-  describe "#prompt" do
-    it "returns the correct prompt" do
-      strategy = OpenAiService::Strategies::ExtractMainContentStrategy.new
-      expected_prompt = <<~PROMPT.strip
-        You are an assistant that processes HTML documents and extracts the main content. \
-        Remove all non-essential elements such as navigation, advertisements, and footers. \
-        Format the main content into sections with titles and paragraphs. The title should be \
-        put in an H2 tag, and the paragraphs should be put in P tags. HTML tags within the \
-        body content should be preserved.
-      PROMPT
-      expect(strategy.prompt).to eq(expected_prompt)
-    end
-  end
-
   describe "#content" do
     it "sanitizes the HTML content using the provided sanitizer" do
       html_content = "<html><body><h1>Main Content</h1><p>This is a paragraph.</p></body></html>"

--- a/spec/models/crawl_request_spec.rb
+++ b/spec/models/crawl_request_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe CrawlRequest, type: :model do
     it { should have_db_column(:analysis).of_type(:jsonb).with_options(default: {}) }
   end
 
+  describe "associations" do
+    it { should have_one_attached(:html_response) }
+    it { should have_one(:web_page_draft) }
+  end
+
   describe "validations" do
     it { should validate_presence_of(:url) }
     it { should validate_presence_of(:status) }

--- a/spec/models/web_page_draft_spec.rb
+++ b/spec/models/web_page_draft_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe WebPageDraft, type: :model do
+  describe "associations" do
+    it { should belong_to(:crawl_request).optional }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:title) }
+    it { should validate_presence_of(:body) }
+  end
+end

--- a/spec/models/web_page_draft_spec.rb
+++ b/spec/models/web_page_draft_spec.rb
@@ -7,15 +7,5 @@ RSpec.describe WebPageDraft, type: :model do
 
   describe "validations" do
     it { should validate_presence_of(:title) }
-    it { should validate_presence_of(:body) }
-
-    it "validates that body is valid JSON" do
-      valid_json = build(:web_page_draft, body: '{"content": [{"title": "Section 1", "html": "<p>Content</p>"}]}')
-      invalid_json = build(:web_page_draft, body: "invalid_json")
-
-      expect(valid_json).to be_valid
-      expect(invalid_json).not_to be_valid
-      expect(invalid_json.errors[:body]).to include("must be valid JSON")
-    end
   end
 end

--- a/spec/models/web_page_draft_spec.rb
+++ b/spec/models/web_page_draft_spec.rb
@@ -8,5 +8,14 @@ RSpec.describe WebPageDraft, type: :model do
   describe "validations" do
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:body) }
+
+    it "validates that body is valid JSON" do
+      valid_json = build(:web_page_draft, body: '{"content": [{"title": "Section 1", "html": "<p>Content</p>"}]}')
+      invalid_json = build(:web_page_draft, body: "invalid_json")
+
+      expect(valid_json).to be_valid
+      expect(invalid_json).not_to be_valid
+      expect(invalid_json.errors[:body]).to include("must be valid JSON")
+    end
   end
 end


### PR DESCRIPTION
### Changes

The results of the API request to OpenAI are saved in a new model `WebPageDraft`, which is associated to the crawl request.

### Why?

This is the next step toward the goal of providing a user with a clean version of the primary content of a given webpage. Once we have that locked in, we can tackle allowing the user to modify it, e.g. request rewriting specific sections to suit their SEO goals.

### Screenshots

![Screenshot 2024-06-26 at 7 25 12 AM](https://github.com/seanmack/copydog-ai/assets/5815877/28a9df18-53d2-4cb9-8906-05e4adedadba)

![Screenshot 2024-06-26 at 7 27 24 AM](https://github.com/seanmack/copydog-ai/assets/5815877/e9680aa9-006b-48dd-8449-fc5a904fe52e)
