### PR TITLE
Prevent text encoding errors

### DIFF
--- a/app/decorators/crawl_request_decorator.rb
+++ b/app/decorators/crawl_request_decorator.rb
@@ -1,0 +1,25 @@
+class CrawlRequestDecorator
+  def initialize(crawl_request)
+    @crawl_request = crawl_request
+  end
+
+  def html
+    return unless html_response?
+
+    @html ||= @crawl_request.html_response.open do |file|
+      File.read(file)
+    end
+  end
+
+  def sanitized_html
+    return unless html_response?
+
+    Sanitizers::SimpleSanitizer.new(html_content: html).sanitize
+  end
+
+  private
+
+  def html_response?
+    @crawl_request.html_response.attached?
+  end
+end

--- a/app/jobs/crawl_web_page_job.rb
+++ b/app/jobs/crawl_web_page_job.rb
@@ -17,18 +17,20 @@ class CrawlWebPageJob < ApplicationJob
   # TODO: This needs a refactor. But while we're still
   # developing the feature, it's easiest to see everything in one place.
   def handle_success(crawl_request, result)
+    html_response = result[:body].force_encoding("UTF-8")
+
     # Purge the existing attachment if it exists
     crawl_request.html_response.purge if crawl_request.html_response.attached?
 
     # Attach the new HTML response
     crawl_request.html_response.attach(
-      io: StringIO.new(result[:body]),
+      io: StringIO.new(html_response),
       filename: "crawl_response_#{crawl_request.id}.html",
       content_type: "text/html"
     )
 
     # Parse the page and send the HTML for analysis (this will need error handling)
-    page_analysis = PageAnalysis::Parser.new(content: result[:body])
+    page_analysis = PageAnalysis::Parser.new(content: html_response)
 
     # Update the crawl request with the analysis results
     crawl_request.update!(
@@ -39,7 +41,7 @@ class CrawlWebPageJob < ApplicationJob
     )
 
     # Ask OpenAI to analyze the content of the page
-    body = SendContentForAnalysis.new(html: result[:body]).call
+    body = SendContentForAnalysis.new(html: html_response).call
 
     # Create a web page draft with the analysis results
     web_page_draft = WebPageDraft.find_or_initialize_by(crawl_request:)

--- a/app/views/admin/crawl_requests/show.html.erb
+++ b/app/views/admin/crawl_requests/show.html.erb
@@ -71,11 +71,17 @@ as well as a link to its edit page.
   </dl>
 
   <%# TODO: this is just a quick way of displaying the results for now %>
-  <% if page.resource.html_response.attached? %>
+    <% decorator = CrawlRequestDecorator.new(page.resource) %>
+
+    <h2>Sanitized HTML</h2>
+    <div style="overflow-x: auto;">
+      <pre><code><%= decorator.sanitized_html %></code></pre>
+    </div>
+
+    <hr>
+
     <h2>Original HTML response</h2>
     <div style="overflow-x: auto;">
-      <% html = page.resource.html_response.download %>
-      <pre><code><%= html %></code></pre>
+      <pre><code><%= decorator.html %></code></pre>
     </div>
-  <% end %>
 </section>

--- a/spec/decorators/crawl_request_decorator_spec.rb
+++ b/spec/decorators/crawl_request_decorator_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe CrawlRequestDecorator, type: :model do
+  describe "#html" do
+    context "when html_response is attached" do
+      it "returns the html content" do
+        crawl_request = setup_crawl_request_with_html
+        decorator = described_class.new(crawl_request)
+
+        expect(decorator.html).to eq("<html><body>Hello World</body></html>")
+      end
+    end
+
+    context "when html_response is not attached" do
+      it "returns nil" do
+        crawl_request = create(:crawl_request)
+        decorator = described_class.new(crawl_request)
+
+        expect(decorator.html).to be_nil
+      end
+    end
+  end
+
+  describe "#sanitized_html" do
+    context "when html_response is attached" do
+      it "returns the sanitized html content" do
+        crawl_request = setup_crawl_request_with_html
+        decorator = described_class.new(crawl_request)
+
+        sanitizer = instance_double(Sanitizers::SimpleSanitizer, sanitize: "Hello World")
+        allow(Sanitizers::SimpleSanitizer).to receive(:new).with(html_content: "<html><body>Hello World</body></html>").and_return(sanitizer)
+
+        expect(decorator.sanitized_html).to eq("Hello World")
+      end
+    end
+
+    context "when html_response is not attached" do
+      it "returns nil" do
+        crawl_request = create(:crawl_request)
+        decorator = described_class.new(crawl_request)
+
+        expect(decorator.sanitized_html).to be_nil
+      end
+    end
+  end
+
+  def create_attached_blob(crawl_request, content)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(content),
+      filename: "response.html",
+      content_type: "text/html"
+    )
+    crawl_request.html_response.attach(blob)
+  end
+
+  def setup_crawl_request_with_html
+    crawl_request = create(:crawl_request)
+    create_attached_blob(crawl_request, "<html><body>Hello World</body></html>")
+    crawl_request
+  end
+end


### PR DESCRIPTION
### Changes

Adds `CrawlRequestDecorator` to ensure that text is encoded correctly before rendering it in the view.

### Why?

I've been seeing sporadic errors involving `html_response`. Specifically, the issue is that the text is ASCII-8BIT, not UTF-8 as expected. 

My initial attempt at a fix was to make sure the HTML retrieved during the crawl is encoded properly, but inevitably the text was eventually re-encoded as ASCII-8BIT.

Then I came across [this StackOverflow thread](https://stackoverflow.com/questions/53586249/activestorage-csv-file-force-encoding).

The gist is that ActiveStorage encoding issues can occur if you simply use `resource.my_attachment.download` to download a blob to disk. 

The recommended solution is to instead use `open` and then read the result via a temporary file, so that's what I've put in place for now.