### PR TITLE
Refactor crawl job logic

### DIFF
--- a/spec/lib/open_ai_service/client_spec.rb
+++ b/spec/lib/open_ai_service/client_spec.rb
@@ -16,10 +16,9 @@ RSpec.describe OpenAiService::Client do
         ]
       }
 
-      client = OpenAiService::Client.new
-      allow(client).to receive(:initialize).and_return(OpenAI::Client.new)
       allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(response_body)
 
+      client = OpenAiService::Client.new
       result = client.send_request(prompt:, content:)
 
       expect(result).to eq("Test response")


### PR DESCRIPTION
### Changes

Refactors the job that handles downloading and processing HTML content.

### Why?

The `handle_success` method was really long because I wanted to postpone any refactors until after the entire flow was working as expected. Now that everything is working well, it's time do some cleanup.

Note: I also added a minor tweak to improve a spec that was logging warning messages when running the specs.