### PR TITLE
Create bulk crawl requests

### DIFF
--- a/app/controllers/admin/bulk_crawl_jobs_controller.rb
+++ b/app/controllers/admin/bulk_crawl_jobs_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  class BulkCrawlJobsController < Admin::ApplicationController
+    def create
+      bulk_crawl_request = BulkCrawlRequest.find(params[:bulk_crawl_request_id])
+      CrawlWebPagesJob.perform_later(bulk_crawl_request.id)
+      redirect_to admin_bulk_crawl_request_path(bulk_crawl_request), notice: "CrawlWebPagesJob job has been triggered."
+    end
+  end
+end

--- a/app/controllers/admin/bulk_crawl_requests_controller.rb
+++ b/app/controllers/admin/bulk_crawl_requests_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class BulkCrawlRequestsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/bulk_crawl_request_dashboard.rb
+++ b/app/dashboards/bulk_crawl_request_dashboard.rb
@@ -41,7 +41,6 @@ class BulkCrawlRequestDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    crawl_requests
     urls
   ].freeze
 

--- a/app/dashboards/bulk_crawl_request_dashboard.rb
+++ b/app/dashboards/bulk_crawl_request_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class CrawlRequestDashboard < Administrate::BaseDashboard
+class BulkCrawlRequestDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -9,14 +9,8 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
-    failure_message: Field::String,
-    url: Field::String,
-    title: Field::String,
-    meta_description: Field::String,
-    html_response: AttachmentField,
-    web_page_draft: Field::HasOne,
-    bulk_crawl_request: Field::BelongsTo,
+    crawl_requests: Field::HasMany,
+    urls: Field::Text,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -28,24 +22,17 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
-    bulk_crawl_request
-    status
-    failure_message
-    url
+    crawl_requests
+    urls
+    created_at
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
-    bulk_crawl_request
-    status
-    failure_message
-    url
-    title
-    meta_description
-    html_response
-    web_page_draft
+    crawl_requests
+    urls
     created_at
     updated_at
   ].freeze
@@ -54,10 +41,8 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    bulk_crawl_request
-    status
-    failure_message
-    url
+    crawl_requests
+    urls
   ].freeze
 
   # COLLECTION_FILTERS
@@ -72,10 +57,10 @@ class CrawlRequestDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how crawl requests are displayed
+  # Overwrite this method to customize how bulk crawl requests are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(crawl_request)
-  #   "CrawlRequest ##{crawl_request.id}"
+  # def display_resource(bulk_crawl_request)
+  #   "BulkCrawlRequest ##{bulk_crawl_request.id}"
   # end
 end

--- a/app/jobs/crawl_web_pages_job.rb
+++ b/app/jobs/crawl_web_pages_job.rb
@@ -1,0 +1,33 @@
+class CrawlWebPagesJob < ApplicationJob
+  queue_as :default
+
+  def perform(bulk_crawl_request_id)
+    bulk_crawl_request = BulkCrawlRequest.find(bulk_crawl_request_id)
+    urls = extract_urls(bulk_crawl_request:)
+    create_crawl_requests(urls:, bulk_crawl_request:)
+    trigger_crawl_jobs(bulk_crawl_request:)
+  end
+
+  private
+
+  def extract_urls(bulk_crawl_request:)
+    TextListParser.new(text_list: bulk_crawl_request.urls).items
+  end
+
+  def create_crawl_requests(urls:, bulk_crawl_request:)
+    urls.each do |url|
+      crawl_request = CrawlRequest.create(url:, bulk_crawl_request:)
+
+      if !crawl_request.valid?
+        Rails.logger.error("Failed to create CrawlRequest for URL: #{url}")
+        next
+      end
+    end
+  end
+
+  def trigger_crawl_jobs(bulk_crawl_request:)
+    bulk_crawl_request.crawl_requests.each do |crawl_request|
+      CrawlWebPageJob.perform_later(crawl_request.id)
+    end
+  end
+end

--- a/app/models/bulk_crawl_request.rb
+++ b/app/models/bulk_crawl_request.rb
@@ -1,0 +1,3 @@
+class BulkCrawlRequest < ApplicationRecord
+  has_many :crawl_requests
+end

--- a/app/models/crawl_request.rb
+++ b/app/models/crawl_request.rb
@@ -3,6 +3,7 @@
 class CrawlRequest < ApplicationRecord
   has_one_attached :html_response
   has_one :web_page_draft
+  belongs_to :bulk_crawl_request, optional: true
 
   enum :status, { pending: 0, in_progress: 10, completed: 20, failed: 30 }
 

--- a/app/services/text_list_parser.rb
+++ b/app/services/text_list_parser.rb
@@ -1,0 +1,15 @@
+# Converts a string into an array of items
+
+class TextListParser
+  attr_reader :text_list
+
+  def initialize(text_list:)
+    @text_list = text_list
+  end
+
+  def items
+    return [] unless text_list.present?
+
+    text_list.split("\n").map(&:strip).reject(&:empty?)
+  end
+end

--- a/app/views/admin/bulk_crawl_requests/show.html.erb
+++ b/app/views/admin/bulk_crawl_requests/show.html.erb
@@ -1,0 +1,72 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if accessible_action?(page.resource, :edit) %>
+
+    <%= link_to(
+      t("administrate.actions.destroy"),
+      [namespace, page.resource],
+      class: "button button--danger",
+      method: :delete,
+      data: { confirm: t("administrate.actions.confirm") }
+    ) if accessible_action?(page.resource, :destroy) %>
+
+    <%= link_to(
+      "Trigger Bulk Crawl",
+      admin_bulk_crawl_request_bulk_crawl_jobs_path(page.resource),
+      method: :post,
+      class: "button"
+    ) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |title, attributes| %>
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend><%= t "helpers.label.#{page.resource_name}.#{title}", default: title %></legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label" id="<%= attribute.name %>">
+          <%= t(
+            "helpers.label.#{resource_name}.#{attribute.name}",
+            default: page.resource.class.human_attribute_name(attribute.name),
+          ) %>
+          </dt>
+
+          <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+              ><%= render_field attribute, page: page %></dd>
+        <% end %>
+      </fieldset>
+    <% end %>
+  </dl>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,11 @@ Rails.application.routes.draw do
         resources :crawl_jobs, only: [:create]
       end
 
+      resources :bulk_crawl_requests do
+        resources :bulk_crawl_jobs, only: [:create]
+      end
+
       resources :web_page_drafts
-      resources :bulk_crawl_requests
 
       root to: "crawl_requests#index"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       end
 
       resources :web_page_drafts
+      resources :bulk_crawl_requests
 
       root to: "crawl_requests#index"
     end

--- a/db/migrate/20240629212703_create_bulk_crawl_requests.rb
+++ b/db/migrate/20240629212703_create_bulk_crawl_requests.rb
@@ -1,0 +1,8 @@
+class CreateBulkCrawlRequests < ActiveRecord::Migration[7.2]
+  def change
+    create_table :bulk_crawl_requests do |t|
+      t.text :urls
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240629213724_add_bulk_crawl_request_id_to_crawl_requests.rb
+++ b/db/migrate/20240629213724_add_bulk_crawl_request_id_to_crawl_requests.rb
@@ -1,0 +1,5 @@
+class AddBulkCrawlRequestIdToCrawlRequests < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :crawl_requests, :bulk_crawl_request, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_06_25_105849) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_29_213724) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_25_105849) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "bulk_crawl_requests", force: :cascade do |t|
+    t.text "urls"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "crawl_requests", force: :cascade do |t|
     t.string "url", null: false
     t.integer "status", default: 0, null: false
@@ -49,6 +55,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_25_105849) do
     t.datetime "updated_at", null: false
     t.string "failure_message"
     t.jsonb "analysis", default: {}
+    t.bigint "bulk_crawl_request_id"
+    t.index ["bulk_crawl_request_id"], name: "index_crawl_requests_on_bulk_crawl_request_id"
   end
 
   create_table "web_page_drafts", force: :cascade do |t|
@@ -62,5 +70,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_25_105849) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "crawl_requests", "bulk_crawl_requests"
   add_foreign_key "web_page_drafts", "crawl_requests"
 end

--- a/spec/jobs/crawl_web_pages_job_spec.rb
+++ b/spec/jobs/crawl_web_pages_job_spec.rb
@@ -1,0 +1,55 @@
+# spec/jobs/crawl_web_pages_job_spec.rb
+require "rails_helper"
+
+RSpec.describe CrawlWebPagesJob, type: :job do
+  describe "#perform" do
+    it "extracts URLs from the bulk_crawl_request" do
+      bulk_crawl_request = create_bulk_crawl_request(urls: "http://example.com\nhttp://test.com")
+      job = CrawlWebPagesJob.new
+
+      allow(job).to receive(:create_crawl_requests)
+      allow(job).to receive(:trigger_crawl_jobs)
+
+      expect(TextListParser).to receive(:new).with(text_list: bulk_crawl_request.urls).and_call_original
+      job.perform(bulk_crawl_request.id)
+    end
+
+    it "creates crawl requests for each URL" do
+      bulk_crawl_request = create_bulk_crawl_request(urls: "http://example.com\nhttp://test.com")
+      urls = ["http://example.com", "http://test.com"]
+      job = CrawlWebPagesJob.new
+
+      allow(job).to receive(:trigger_crawl_jobs)
+
+      expect {
+        job.perform(bulk_crawl_request.id)
+      }.to change { CrawlRequest.count }.by(2)
+
+      urls.each do |url|
+        expect(CrawlRequest.exists?(url:, bulk_crawl_request:)).to be true
+      end
+    end
+
+    it "logs an error if a CrawlRequest is invalid" do
+      bulk_crawl_request = create_bulk_crawl_request(urls: "invalid-url")
+      job = CrawlWebPagesJob.new
+
+      allow(job).to receive(:trigger_crawl_jobs)
+
+      expect(Rails.logger).to receive(:error).with("Failed to create CrawlRequest for URL: invalid-url")
+      job.perform(bulk_crawl_request.id)
+    end
+
+    it "triggers crawl jobs for each CrawlRequest" do
+      bulk_crawl_request = create_bulk_crawl_request(urls: "http://example.com\nhttp://test.com")
+      job = CrawlWebPagesJob.new
+
+      expect(CrawlWebPageJob).to receive(:perform_later).twice
+      job.perform(bulk_crawl_request.id)
+    end
+  end
+
+  def create_bulk_crawl_request(urls:)
+    BulkCrawlRequest.create(urls: urls)
+  end
+end

--- a/spec/models/bulk_crawl_request_spec.rb
+++ b/spec/models/bulk_crawl_request_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe BulkCrawlRequest, type: :model do
+  it { should have_many(:crawl_requests) }
+end

--- a/spec/models/crawl_request_spec.rb
+++ b/spec/models/crawl_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CrawlRequest, type: :model do
   describe "associations" do
     it { should have_one_attached(:html_response) }
     it { should have_one(:web_page_draft) }
+    it { should belong_to(:bulk_crawl_request).optional }
   end
 
   describe "validations" do

--- a/spec/services/text_list_parser_spec.rb
+++ b/spec/services/text_list_parser_spec.rb
@@ -1,0 +1,46 @@
+# spec/text_list_parser_spec.rb
+require "rails_helper"
+
+RSpec.describe TextListParser, type: :model do
+  describe "#items" do
+    it "returns an empty array if the input is nil" do
+      parser = TextListParser.new(text_list: nil)
+      expect(parser.items).to eq([])
+    end
+
+    it "returns an empty array if the input is an empty string" do
+      parser = TextListParser.new(text_list: "")
+      expect(parser.items).to eq([])
+    end
+
+    it "returns an array of items when input contains items separated by newlines" do
+      input = "item1\nitem2"
+      parser = TextListParser.new(text_list: input)
+      expect(parser.items).to eq(["item1", "item2"])
+    end
+
+    it "handles leading and trailing whitespace in items" do
+      input = "  item1  \n  item2  "
+      parser = TextListParser.new(text_list: input)
+      expect(parser.items).to eq(["item1", "item2"])
+    end
+
+    it "ignores empty lines" do
+      input = "item1\n\nitem2"
+      parser = TextListParser.new(text_list: input)
+      expect(parser.items).to eq(["item1", "item2"])
+    end
+
+    it "handles carriage return characters" do
+      input = "item1\r\nitem2"
+      parser = TextListParser.new(text_list: input)
+      expect(parser.items).to eq(["item1", "item2"])
+    end
+
+    it "handles a mixture of all scenarios" do
+      input = "\r\n  item1  \r\n\n  item2  \n\n"
+      parser = TextListParser.new(text_list: input)
+      expect(parser.items).to eq(["item1", "item2"])
+    end
+  end
+end


### PR DESCRIPTION
### Changes

A user can add a list of URLs and create a new web page draft for each. As with the individual page crawls, the fetched content is sanitized and processed by the OpenAI API.

### Why?

Crawling URLs in bulk is a critical feature. It's typical for a website owner to have a list of URLs they want to evaluate or clone, and this new feature allows them to add a list of URLs and then generate a web page draft for each.

### Notes

There are still some decisions that need to be made about how this should work. Should users be able to trigger this more than once? If so, should the associated CrawlRequests be updated or should new ones be created?

Also, the admin view is getting cluttered. While it won't be customer-facing, it does need to be functional, so it might be time soon to start planning out where the various resources will live.

### Screenshots

![Screenshot 2024-06-29 at 5 53 45 PM](https://github.com/seanmack/copydog-ai/assets/5815877/8bfc0326-e4fa-42d0-9242-20c295d936ee)
![Screenshot 2024-06-29 at 5 53 59 PM](https://github.com/seanmack/copydog-ai/assets/5815877/955b81a5-0378-49f3-93d1-3ec289bfaf1e)
![Screenshot 2024-06-29 at 5 54 58 PM](https://github.com/seanmack/copydog-ai/assets/5815877/310b2d66-3c52-41c4-ac67-066a545ee819)
![Screenshot 2024-06-29 at 5 56 10 PM](https://github.com/seanmack/copydog-ai/assets/5815877/71a57a00-91b9-4c46-b673-def15b60709f)
