### PR TITLE
Add freezolite gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem "administrate"
+gem "freezolite"
 gem "htmlbeautifier"
 gem "httparty"
 gem "ruby-openai"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     ffi (1.17.0-x86-linux-gnu)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    freezolite (0.5.0)
+      require-hooks (~> 0.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.0)
@@ -269,6 +271,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
+    require-hooks (0.2.2)
     rexml (3.3.0)
       strscan
     rspec-core (3.13.0)
@@ -400,6 +403,7 @@ DEPENDENCIES
   debug
   dotenv
   factory_bot_rails
+  freezolite
   htmlbeautifier
   httparty
   importmap-rails

--- a/app/jobs/crawl_web_page_job.rb
+++ b/app/jobs/crawl_web_page_job.rb
@@ -31,7 +31,7 @@ class CrawlWebPageJob < ApplicationJob
   end
 
   def encode_html_response(result:)
-    result[:body].force_encoding("UTF-8")
+    result[:body].encode("UTF-8")
   end
 
   def attach_html_response(crawl_request:, html_response:)

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,9 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# Enable frozen string literals by default
+require "freezolite/auto"
+
 module Copydog
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
### Changes

Adds freezolite gem to enable frozen string literals by default.

### Why?

I've been procrastinating adding magic comments to all the Ruby files, partly because I don't need any performance tuning yet and partly because I just didn't feel like dealing with them.  

Then I stumbled on the freezolite gem. Full details about what it does here: https://evilmartians.com/chronicles/freezolite-the-magic-gem-for-keeping-ruby-literals-safely-frozen

So far this seems like a great solution. Running the specs immediately identified an issue, so I think it's working as expected. 


 https://github.com/ruby-next/freezolite