### PR TITLE
Add initial class documentation

### DIFF
--- a/app/services/send_content_for_analysis.rb
+++ b/app/services/send_content_for_analysis.rb
@@ -1,3 +1,16 @@
+# Sends HTML content for analysis using a specified strategy.
+#
+# @param html [String] The HTML content to be analyzed.
+# @param client [Class] The client class to use for sending the request. Defaults to OpenAiService::Client.
+# @param strategy [Class] The strategy class to use for extracting main content. Defaults to OpenAiService::Strategies::ExtractMainContentStrategy.
+#
+# @example
+#   analysis = SendContentForAnalysis.new(html: "<html>...</html>")
+#   result = analysis.call
+#   # result contains the response from the analysis service.
+#
+# @return [String/nil] The response from the client request.
+
 class SendContentForAnalysis
   attr_reader :html, :client, :strategy
 

--- a/app/services/text_list_parser.rb
+++ b/app/services/text_list_parser.rb
@@ -1,4 +1,13 @@
-# Converts a string into an array of items
+# Parses a list of text items separated by newlines.
+#
+# @param text_list [String] The text containing newline-separated items.
+#
+# @example
+#   parser = TextListParser.new(text_list: "item1\nitem2\nitem3")
+#   items = parser.items
+#   # items => ["item1", "item2", "item3"]
+#
+# @return [Array<String>] An array of stripped, non-empty items.
 
 class TextListParser
   attr_reader :text_list

--- a/lib/open_ai_service/client.rb
+++ b/lib/open_ai_service/client.rb
@@ -1,4 +1,16 @@
 module OpenAiService
+  # A client for interacting with the OpenAI service.
+  #
+  # @example
+  #   client = OpenAiService::Client.new
+  #   response = client.send_request(prompt: "Analyze this text", content: "Sample content")
+  #   # response contains the content of the AI's reply.
+  #
+  # @param prompt [String] The system prompt to send to the AI.
+  # @param content [String] The user content to analyze.
+  #
+  # @return [String, nil] The content of the AI's response, or nil if not found.
+
   class Client
     def initialize
       @client = OpenAI::Client.new

--- a/lib/open_ai_service/strategies/base_strategy.rb
+++ b/lib/open_ai_service/strategies/base_strategy.rb
@@ -1,5 +1,7 @@
 module OpenAiService
   module Strategies
+    # Base class for OpenAI service strategies. See subclasses for usage.
+
     class BaseStrategy
       def prompt
         raise NotImplementedError, "Subclasses must implement the prompt method"

--- a/lib/open_ai_service/strategies/extract_main_content_strategy.rb
+++ b/lib/open_ai_service/strategies/extract_main_content_strategy.rb
@@ -1,5 +1,17 @@
 module OpenAiService
   module Strategies
+    # Strategy for extracting main content from HTML documents.
+    # This strategy removes non-essential elements and formats the main content into sections.
+    #
+    # Example usage:
+    #   strategy = OpenAiService::Strategies::ExtractMainContentStrategy.new
+    #   prompt = strategy.prompt
+    #   content = strategy.content(html_content: "<html>...</html>", sanitizer: CustomSanitizer)
+    #
+    # Parameters:
+    # - html_content: The HTML content to process.
+    # - sanitizer: The sanitizer class used to clean the HTML content (default is SimpleSanitizer).
+
     class ExtractMainContentStrategy < BaseStrategy
       def prompt
         <<~PROMPT.strip

--- a/lib/page_analysis/meta_description_extractor.rb
+++ b/lib/page_analysis/meta_description_extractor.rb
@@ -1,4 +1,7 @@
 module PageAnalysis
+  # Extracts the meta description from an HTML document. See
+  # PageAnalysis::Parser for usage.
+
   class MetaDescriptionExtractor
     def self.extract(doc)
       meta_tag = doc.at_css("meta[name='description']")

--- a/lib/page_analysis/parser.rb
+++ b/lib/page_analysis/parser.rb
@@ -1,4 +1,13 @@
 module PageAnalysis
+  # Parses HTML content to extract the title and meta description.
+  #
+  # @param content [String] the HTML content to be analyzed.
+  #
+  # @example
+  #   parser = PageAnalysis::Parser.new(content: '<html>...</html>')
+  #   parser.title # => 'Page Title'
+  #   parser.meta_description # => 'Page meta description'
+
   class Parser
     attr_reader :content, :title, :meta_description
 

--- a/lib/page_analysis/title_extractor.rb
+++ b/lib/page_analysis/title_extractor.rb
@@ -1,4 +1,6 @@
 module PageAnalysis
+  # Extracts the title from an HTML document.
+
   class TitleExtractor
     def self.extract(doc)
       doc.at_css("title")&.text.presence

--- a/lib/sanitizers/base_sanitizer.rb
+++ b/lib/sanitizers/base_sanitizer.rb
@@ -1,4 +1,6 @@
 module Sanitizers
+  # Base class for sanitizing HTML content. See subclasses for usage.
+
   class BaseSanitizer
     def sanitize
       raise NotImplementedError, "Subclasses must implement the sanitize method"

--- a/lib/sanitizers/simple_sanitizer.rb
+++ b/lib/sanitizers/simple_sanitizer.rb
@@ -1,4 +1,13 @@
 module Sanitizers
+  # Sanitizes HTML content by extracting inner HTML, removing elements, and beautifying the content.
+  #
+  # @param html_content [String] the HTML content to be sanitized.
+  # @return [String] the sanitized HTML content.
+  #
+  # @example
+  #   sanitizer = Sanitizers::SimpleSanitizer.new(html_content: '<html>...</html>')
+  #   sanitized_content = sanitizer.sanitize # => sanitized HTML content
+
   class SimpleSanitizer < BaseSanitizer
     attr_reader :html_content
 

--- a/lib/sanitizers/utilities/base_utility.rb
+++ b/lib/sanitizers/utilities/base_utility.rb
@@ -1,5 +1,8 @@
 module Sanitizers
   module Utilities
+    # Base class for utility classes used in sanitizing HTML content.
+    # See subclasses for usage.
+
     class BaseUtility
       attr_reader :html_content
 

--- a/lib/sanitizers/utilities/beautifier.rb
+++ b/lib/sanitizers/utilities/beautifier.rb
@@ -1,5 +1,7 @@
 module Sanitizers
   module Utilities
+    # Formats and normalizes HTML content using the HtmlBeautifier gem.
+
     class Beautifier < BaseUtility
       def beautify
         HtmlBeautifier.beautify(html_content)

--- a/lib/sanitizers/utilities/element_remover.rb
+++ b/lib/sanitizers/utilities/element_remover.rb
@@ -1,5 +1,15 @@
 module Sanitizers
   module Utilities
+    # Removes specified elements and attributes from HTML content based on a configuration.
+    #
+    # @param html_content [String] the HTML content to be sanitized.
+    # @param config [Hash] the configuration for element removal (optional).
+    # @return [String] the HTML content with specified elements removed.
+    #
+    # @example
+    #   remover = Sanitizers::Utilities::ElementRemover.new(html_content: '<html>...</html>')
+    #   cleaned_content = remover.remove_elements # => sanitized HTML content
+
     class ElementRemover < BaseUtility
       attr_reader :config
 
@@ -12,19 +22,28 @@ module Sanitizers
         Sanitize.fragment(html_content, config)
       end
 
+      # Default configuration for the ElementRemover utility. These settings
+      # are a good starting point for most sanitization tasks, but we will
+      # likely need to customize them for specific use cases.
       DEFAULT_SANITIZER_CONFIG = {
+        # Remove all elements except the following:
         elements: %w[div span p a ul ol li],
+
+        # Remove all attributes except the following:
         attributes: {
           "a" => %w[href]
         },
+
+        # Remove all protocols except the following:
         protocols: {
           "a" => { "href" => ["http", "https"] }
         },
+
+        # Remove empty nodes and nodes with only whitespace
         transformers: lambda do |env|
           node = env[:node]
           return unless node.elem?
 
-          # Remove empty nodes
           unless node.children.any? { |c| !c.text? || c.content.strip.length > 0 }
             node.unlink
           end

--- a/lib/sanitizers/utilities/inner_html_extractor.rb
+++ b/lib/sanitizers/utilities/inner_html_extractor.rb
@@ -1,5 +1,15 @@
 module Sanitizers
   module Utilities
+    # Extracts inner HTML from a specified element in the HTML content.
+    #
+    # @param html_content [String] the HTML content to extract from.
+    # @param element [String] the CSS selector of the element to extract inner HTML from.
+    # @return [String, nil] the inner HTML of the specified element, or nil if not found.
+    #
+    # @example
+    #   extractor = Sanitizers::Utilities::InnerHtmlExtractor.new(html_content: '<html><body>Content</body></html>', element: 'body')
+    #   inner_html = extractor.extract_inner_html # => 'Content'
+
     class InnerHtmlExtractor < BaseUtility
       attr_reader :element
 


### PR DESCRIPTION
### Changes

Adds initial documentation for custom classes.

### Why?

Now that I'm reasonably confident these classes are going to continue to have these responsibilities, it's worth documenting what those responsibilities are. 

I try not to document too much when things early on when things are in flux, only because I lose too much time rewriting documentation as I change my mind about the implementation. But now seems like a good time to start committing to some decisions.